### PR TITLE
Fix: Prevent fetching unread notifications count when user is not log…

### DIFF
--- a/src/common/components/Navbar.jsx
+++ b/src/common/components/Navbar.jsx
@@ -15,11 +15,15 @@ const Navbar = ({ children }) => {
 
   useEffect(() => {
     const fetchUnreadCount = async () => {
-      try {
-        const count = await getUnreadNotificationsCount(user.uid);
-        setUnreadCount(count);
-      } catch (error) {
-        console.error("Error fetching unread notifications count:", error);
+      if (user) {
+        try {
+          const count = await getUnreadNotificationsCount(user.uid);
+          setUnreadCount(count);
+        } catch (error) {
+          console.error("Error fetching unread notifications count:", error);
+        }
+      } else {
+        setUnreadCount(0); 
       }
     };
 


### PR DESCRIPTION
This pull request includes a small but important change to the `Navbar` component in `src/common/components/Navbar.jsx`. The change ensures that the `fetchUnreadCount` function checks if a `user` exists before attempting to fetch the unread notifications count, and sets the unread count to `0` if no user is logged in.